### PR TITLE
upgrade to praetor@0.0.9

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -81,8 +81,8 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
     },
     "praetor": {
-      "version": "0.0.8",
-      "from": "praetor@^0.0.8",
+      "version": "0.0.9",
+      "from": "praetor@^0.0.9",
       "dependencies": {
         "eventemitter2": {
           "version": "0.4.14",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "async": "^0.8.0",
     "body-parser": "^1.4.3",
     "lodash": "^2.4.1",
-    "praetor": "^0.0.8",
+    "praetor": "^0.0.9",
     "request": "^2.51.0",
     "winston": "^0.7.3"
   },


### PR DESCRIPTION
praetor@0.0.9 fixes a known leader election bug occurring when hosts leave the cluster